### PR TITLE
Fix heroku  URL + logo, remove deprecated key

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,10 +1,9 @@
 {
     "name": "ButterCMS Django Starter Project ",
-    "description": "A simple project showing how to use ButterCMS with Django.",
-    "repository": "https://github.com/failedguidedog/django-starter-buttercms",
-    "logo": "https://django-starter-buttercms.herokuapp.com/static/images/logo/logo.svg",
-    "keywords": ["django", "python", "buttercms"],
-    "image": "heroku/python",
+    "description": "Drop-in proof-of-concept Django app, fully integrated with your ButterCMS account.",
+    "repository": "https://github.com/ButterCMS/django-starter-buttercms",
+    "logo": "https://cdn.buttercms.com/R3fbtvoRT2CqEQSmk8hb",
+    "keywords": ["django", "python", "buttercms", "cms", "blog"],
     "buildpacks": [
         {
           "url": "heroku/python"


### PR DESCRIPTION
Trello Card: [https://trello.com/c/by0cH7rw/1479-add-heroku-deploy-for-gatsby-and-nextjs](https://trello.com/c/by0cH7rw/1479-add-heroku-deploy-for-gatsby-and-nextjs)

While adding heroku deploy buttons for nextjs and gatsbyjs, I noticed that I'd missed updating some things in the deploy settings for the django app. I fixed those, and I've also removed a key, "image", which [has been deprecated](https://devcenter.heroku.com/articles/app-json-schema#image).

Here is also a video of me deploying this from branch, including previewing in butter iframe: [https://share.getcloudapp.com/z8uLAx8G](https://share.getcloudapp.com/z8uLAx8G)